### PR TITLE
Improve --data option with query string format

### DIFF
--- a/core/channel.py
+++ b/core/channel.py
@@ -58,19 +58,16 @@ class Channel:
                 log.warn('Found placeholder in Header \'%s\'' % param)
 
     def _parse_post(self):
+        
+        datas = urlparse.parse_qs(self.args.get('data', ''))
 
-        for param_value in self.args.get('post_data', '[]'):
+        for param_key, param_value in datas.iteritems() :          
 
-            if '=' not in param_value:
-                continue
+            self.post_params[param_key] = param_value
 
-            param, value = param_value.split('=')
-
-            self.post_params[param] = value
-
-            if '*' in value:
-                self.post_placeholders.append(param)
-                log.warn('Found placeholder in POST parameter \'%s\'' % param)
+            if '*' in param_value:
+                self.post_placeholders.append(param_key)
+                log.warn('Found placeholder in POST parameter \'%s\'' % param_key)
 
     def _parse_get(self):
 

--- a/utils/cliparser.py
+++ b/utils/cliparser.py
@@ -37,7 +37,7 @@ request = OptionGroup(parser, "Request", "These options have how to connect and 
 request.add_option("-d","--data",
                 action="store",
                 dest="data",
-                help="Data string to be sent through POST.",
+                help="Data string to be sent through POST. It must be as query string:\n param1=value1&param2=value2",
                 default=[])
 
 request.add_option("-H","--headers",


### PR DESCRIPTION
I didn't how to use this data option and i think it didn't work with cli.
So i fixed it and now, the format must be as query string in cli

./tplmap.py -u "http://example.com" --data "param1=*&param2=value2"  