### PR TITLE
Fix HTTP Header parser

### DIFF
--- a/core/channel.py
+++ b/core/channel.py
@@ -43,7 +43,7 @@ class Channel:
 
     def _parse_header(self):
         
-        for param_value in self.args.get('headers').split('\r\n'):
+        for param_value in self.args.get('headers').split('\\r\\n'):
 
             if ':' not in param_value:
                 continue

--- a/core/channel.py
+++ b/core/channel.py
@@ -43,7 +43,7 @@ class Channel:
 
     def _parse_header(self):
         
-        for param_value in self.args.get('headers', '[]'):
+        for param_value in self.args.get('headers').split(','):
 
             if ':' not in param_value:
                 continue

--- a/core/channel.py
+++ b/core/channel.py
@@ -43,7 +43,7 @@ class Channel:
 
     def _parse_header(self):
         
-        for param_value in self.args.get('headers').split(','):
+        for param_value in self.args.get('headers').split('\r\n'):
 
             if ':' not in param_value:
                 continue

--- a/utils/cliparser.py
+++ b/utils/cliparser.py
@@ -42,7 +42,7 @@ request.add_option("-d","--data",
 request.add_option("-H","--headers",
                 action="store",
                 dest="headers",
-                help="Extra headers (e.g. 'Header1: Value1').",
+                help="Extra headers (e.g. 'Header1: Value1, Header2: Value2').",
                 default=[])
 
 target.add_option("-X","--request",

--- a/utils/cliparser.py
+++ b/utils/cliparser.py
@@ -42,7 +42,7 @@ request.add_option("-d","--data",
 request.add_option("-H","--headers",
                 action="store",
                 dest="headers",
-                help="Extra headers (e.g. 'Header1: Value1, Header2: Value2').",
+                help="Extra headers (e.g. 'Header1: Value1\\r\\nHeader2: Value2').",
                 default=[])
 
 target.add_option("-X","--request",


### PR DESCRIPTION
HTTP Header argument won't work properly as _parse_header has parsing issue. It's possible to have multiple extra headers, thus added RFC2616 CRLF ("\\r\\n") to support it.