### PR TITLE
Supports HTTP Proxy

### DIFF
--- a/core/channel.py
+++ b/core/channel.py
@@ -21,6 +21,15 @@ class Channel:
         self.injs = []
         self.inj_idx = 0
 
+        proxy = self.args.get('proxy')
+        if proxy:
+            self.proxies = {
+                'http': proxy,
+                'https': proxy
+            }
+        else:
+            self.proxies = {}
+
         self.get_params = {}
         self.post_params = {}
         self.header_params = {}
@@ -211,6 +220,7 @@ class Channel:
             params = get_params,
             data = post_params,
             headers = header_params,
+            proxies = self.proxies,
             # By default, SSL check is skipped.
             # TODO: add a -k curl-like option to set this.
             verify = False

--- a/utils/cliparser.py
+++ b/utils/cliparser.py
@@ -54,6 +54,10 @@ request.add_option("-A","--user-agent",
                 dest="user_agent",
                 help="HTTP User-Agent header value."
                 )
+request.add_option("--proxy",
+                dest="proxy",
+                help="Use a proxy to connect to the target URL"
+                )
 
 # Detection options
 detection = OptionGroup(parser, "Detection" , "These options can be used to customize the detection phase.")


### PR DESCRIPTION
I added proxy support to cli.

```sh
$ python tplmap.py -h
Usage: python tplmap.py [options]

(snip)

  Request:
    These options have how to connect and where to inject to the target
    URL.

    -d DATA, --data=..  Data string to be sent through POST. It must be as
                        query string: param1=value1&param2=value2.
    -H HEADERS, --he..  Extra headers (e.g. 'Header1: Value1'). Use multiple
                        times to add new headers.
    -A USER_AGENT, -..  HTTP User-Agent header value.
    --proxy=PROXY       Use a proxy to connect to the target URL

(snip)
```

I tested that following commands work with burpsuite proxy.
```sh
$ python tplmap.py -u 'http://<ip>:<port>/path?inj=*' --proxy localhost:8080
$ python tplmap.py -u 'https://<ip>:<port>/path?inj=*' --proxy localhost:8080
```

This PR might fix #14.