### PR TITLE
Make --header work with refereres

### DIFF
--- a/core/channel.py
+++ b/core/channel.py
@@ -107,7 +107,7 @@ class Channel:
             if ':' not in param_value:
                 continue
 
-            param, value = param_value.split(':')
+            param, value = param_value.split(':', 1)
             param = param.strip()
             value = value.strip()
 


### PR DESCRIPTION
A referer header typically contains a URL, which includes a ':'. Make the split only split after the first ':'.