### PR TITLE
Updated dependencies fixes

### DIFF
--- a/core/channel.py
+++ b/core/channel.py
@@ -1,4 +1,5 @@
 import requests
+import urllib3
 from utils.loggers import log
 import urlparse
 from copy import deepcopy
@@ -54,7 +55,7 @@ class Channel:
         
         # Disable requests warning in case of 
         # skipped SSL certificate check
-        requests.packages.urllib3.disable_warnings()
+        urllib3.disable_warnings()
         
     def _parse_method(self):
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-PyYAML==3.12
-certifi==2017.11.5
+PyYAML==5.1.2
+certifi==2018.10.15
 chardet==3.0.4
-idna==2.6
-requests==2.18.4
-urllib3==1.22
+idna==2.8
+requests==2.22.0
+urllib3==1.24.1
 wsgiref==0.1.2

--- a/utils/config.py
+++ b/utils/config.py
@@ -9,7 +9,7 @@ config_folder = os.path.dirname(os.path.realpath(__file__))
 # TODO: fix this
 with open(config_folder + "/../config.yml", 'r') as stream:
     try:
-        config = yaml.load(stream)
+        config = yaml.load(stream, Loader=yaml.SafeLoader)
     except yaml.YAMLError as e:
         # logger is not yet loaded, print it roughly
         print('[!][%s] %s' % ('config', e))


### PR DESCRIPTION
Running `tplmap` with updated dependencies I encountered this problem:
```
[+] Tplmap 0.5
    Automatic Server-Side Template Injection Detection and Exploitation Tool

[!][tplmap] Exiting: 'module' object has no attribute 'disable_warnings'
```
To fix this I just imported `urllib3` and called `urllib3.disable_warnings()` instead of `requests.packages.urllib3.disable_warnings()`