### PR TITLE
Explain '*' use for URL paths in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,13 @@ $ ./tplmap.py -u 'http://www.target.com/page?name=John'
     --download REMOTE LOCAL   Download remote files
 ```
 
+In case the injectable parameter is in the path and not a URL parameter, you can use `*` in the URL where the injection point is.
+Example:
+```
+./tplmap.py -u 'http://www.target.com/*'
+```
+
+
 Use `--os-shell` option to launch a pseudo-terminal on the target.
 
 ```


### PR DESCRIPTION
I struggled at first to make it work in a site where the 404 page would display the current URL path, after looking through the code I figured out that '*' can be used.