### PR TITLE
Add parameter command line option

### DIFF
--- a/core/channel.py
+++ b/core/channel.py
@@ -17,6 +17,7 @@ class Channel:
         self.base_url = self.url.split("?")[0] if '?' in self.url else self.url
 
         self.tag = self.args.get('injection_tag')
+        self.param = self.args.get('parameter')
 
         self.data = {}
 

--- a/core/checks.py
+++ b/core/checks.py
@@ -108,39 +108,47 @@ def _print_injection_summary(channel):
     'parameter': channel.injs[channel.inj_idx]['param']
 }))
 
-def detect_template_injection(channel, plugins = plugins):
+def detect_template_injection(channel, plugins = plugins, param = None):
 
     # Loop manually the channel.injs modifying channel's inj_idx
     for i in xrange(len(channel.injs)):
 
-        log.info("Testing if %s parameter '%s' is injectable" % (
-            channel.injs[channel.inj_idx]['field'],
-            channel.injs[channel.inj_idx]['param']
+        attempt = False
+        if param != None:
+            if channel.injs[channel.inj_idx]['param'] == param:
+                attempt = True
+        else:
+            attempt = True
+
+        if attempt:
+            log.info("Testing if %s parameter '%s' is injectable" % (
+                channel.injs[channel.inj_idx]['field'],
+                channel.injs[channel.inj_idx]['param']
+                )
             )
-        )
 
-        current_plugin = None
+            current_plugin = None
 
-        # Iterate all the available plugins until
-        # the first template engine is detected.
-        for plugin in plugins:
+            # Iterate all the available plugins until
+            # the first template engine is detected.
+            for plugin in plugins:
 
-            current_plugin = plugin(channel)
+                current_plugin = plugin(channel)
 
-            # Skip if user specify a specific --engine
-            if channel.args.get('engine') and channel.args.get('engine').lower() != current_plugin.plugin.lower():
-                continue
+                # Skip if user specify a specific --engine
+                if channel.args.get('engine') and channel.args.get('engine').lower() != current_plugin.plugin.lower():
+                    continue
 
-            current_plugin.detect()
+                current_plugin.detect()
 
-            if channel.data.get('engine'):
-                return current_plugin
+                if channel.data.get('engine'):
+                    return current_plugin
 
         channel.inj_idx += 1
 
 def check_template_injection(channel):
 
-    current_plugin = detect_template_injection(channel)
+    current_plugin = detect_template_injection(channel, plugins, channel.param)
 
     # Kill execution if no engine have been found
     if not channel.data.get('engine'):

--- a/utils/cliparser.py
+++ b/utils/cliparser.py
@@ -34,6 +34,11 @@ target.add_option("-u","--url",
 # Request options
 request = OptionGroup(parser, "Request", "These options have how to connect and where to inject to the target URL.")
 
+request.add_option("-p","--parameter",
+                dest="parameter",
+                help="Specify the parameter name to attempt",
+                )
+
 request.add_option("-d","--data",
                 dest="data",
                 help="Data string to be sent through POST. It must be as query string: param1=value1&param2=value2.",


### PR DESCRIPTION
Added the -p or --parameter option as a way to specify which parameter to attempt template injections on. By default all parameters are still tried.

For the example in the Readme:
```python ./tplmap.py -u "http://127.0.0.1:8000/page?name=John&foobar=test" -p name```

Only the name parameter will be tested.

This can be useful for reducing the number of attempts required to exploit and provides an alternate syntax to injecting the '*'  character.