### PR TITLE
Fixing python 3 incompatibilities

### DIFF
--- a/core/channel.py
+++ b/core/channel.py
@@ -1,7 +1,13 @@
 import requests
 import urllib3
 from utils.loggers import log
-import urlparse
+import sys
+
+if sys.version_info.major > 2 :
+    import urllib.parse as urlparse
+else :
+    import urlparse
+
 from copy import deepcopy
 import utils.config
 

--- a/core/checks.py
+++ b/core/checks.py
@@ -23,7 +23,13 @@ from core.clis import Shell, MultilineShell
 from core.tcpserver import TcpServer
 import time
 import telnetlib
-import urlparse
+import sys
+
+if sys.version_info.major > 2 :
+    import urllib.parse as urlparse
+else :
+    import urlparse
+
 import socket
 
 plugins = [
@@ -111,7 +117,12 @@ def _print_injection_summary(channel):
 def detect_template_injection(channel, plugins = plugins):
 
     # Loop manually the channel.injs modifying channel's inj_idx
-    for i in xrange(len(channel.injs)):
+    if sys.version_info.major >= 2 :
+        wrappedRange = range
+    else :
+        wrappedRange = xrange
+
+    for i in wrappedRange(len(channel.injs)):
 
         log.info("Testing if %s parameter '%s' is injectable" % (
             channel.injs[channel.inj_idx]['field'],
@@ -181,14 +192,14 @@ def check_template_injection(channel):
             log.info("""Delay is introduced appending '&& sleep <delay>' to the shell commands. True or False is returned whether it returns successfully or not.""")
 
             if channel.args.get('os_cmd'):
-                print current_plugin.execute_blind(channel.args.get('os_cmd'))
+                print(current_plugin.execute_blind(channel.args.get('os_cmd')))
             elif channel.args.get('os_shell'):
                 log.info('Run commands on the operating system.')
                 Shell(current_plugin.execute_blind, '%s (blind) $ ' % (channel.data.get('os', ''))).cmdloop()
 
         elif channel.data.get('execute'):
             if channel.args.get('os_cmd'):
-                print current_plugin.execute(channel.args.get('os_cmd'))
+                print(current_plugin.execute(channel.args.get('os_cmd')))
             elif channel.args.get('os_shell'):
                 log.info('Run commands on the operating system.')
 
@@ -210,7 +221,7 @@ def check_template_injection(channel):
                 call = current_plugin.render
 
             if channel.args.get('tpl_code'):
-                print call(channel.args.get('tpl_code'))
+                print(call(channel.args.get('tpl_code')))
             elif channel.args.get('tpl_shell'):
                 log.info('Inject multi-line template code. Press ctrl-D to send the lines')
                 MultilineShell(call, '%s > ' % (channel.data.get('engine', ''))).cmdloop()

--- a/core/clis.py
+++ b/core/clis.py
@@ -10,7 +10,7 @@ class Shell(cmd.Cmd):
         self.prompt = prompt
     
     def default(self, line):
-        print self.inject_function(line)
+        print(self.inject_function(line))
     
     def emptyline(self):
         pass
@@ -54,8 +54,8 @@ class MultilineShell(cmd.Cmd):
         if line:
             self.lines.append(line)
 
-        print
-        print self.inject_function('\n'.join(self.lines))
+        print('')
+        print(self.inject_function('\n'.join(self.lines)))
         self.lines = []
         
     

--- a/core/plugin.py
+++ b/core/plugin.py
@@ -1,3 +1,6 @@
+import struct
+import sys
+
 from utils.strings import chunkit, md5
 from utils import rand
 from utils.loggers import log
@@ -13,8 +16,8 @@ import utils.config
 
 def _recursive_update(d, u):
     # Update value of a nested dictionary of varying depth
-    
-    for k, v in u.iteritems():
+
+    for k, v in u.items():
         if isinstance(d, collections.Mapping):
             if isinstance(v, collections.Mapping):
                 r = _recursive_update(d.get(k, {}), v)
@@ -25,6 +28,19 @@ def _recursive_update(d, u):
             d = {k: u[k]}
             
     return d
+
+def compatible_url_safe_base64_encode(input):
+    code_b64 = input
+
+    if sys.version_info.major >= 2:
+        code_b64 = code_b64.encode(encoding='UTF-8')
+
+    code_b64 = base64.urlsafe_b64encode(code_b64)
+
+    if sys.version_info.major >= 2:
+        code_b64 = code_b64.decode(encoding='UTF-8')
+
+    return code_b64
 
 class Plugin(object):
 
@@ -658,7 +674,7 @@ class Plugin(object):
 
         if '%(code_b64)s' in payload:
             log.debug('[b64 encoding] %s' % code)
-            execution_code = payload % ({ 'code_b64' : base64.urlsafe_b64encode(code) })
+            execution_code = payload % ({ 'code_b64' : compatible_url_safe_base64_encode(code) })
         else:
             execution_code = payload % ({ 'code' : code })
 
@@ -685,7 +701,7 @@ class Plugin(object):
 
         if '%(code_b64)s' in payload:
             log.debug('[b64 encoding] %s' % code)
-            execution_code = payload % ({ 'code_b64' : base64.urlsafe_b64encode(code) })
+            execution_code = payload % ({ 'code_b64' : compatible_url_safe_base64_encode(code) })
         else:
             execution_code = payload % ({ 'code' : code })
 
@@ -717,7 +733,7 @@ class Plugin(object):
         if '%(code_b64)s' in payload_action:
             log.debug('[b64 encoding] %s' % code)
             execution_code = payload_action % ({
-                'code_b64' : base64.urlsafe_b64encode(code),
+                'code_b64' : compatible_url_safe_base64_encode(code),
                 'delay' : expected_delay
             })
         else:
@@ -752,7 +768,7 @@ class Plugin(object):
         if '%(code_b64)s' in payload_action:
             log.debug('[b64 encoding] %s' % code)
             execution_code = payload_action % ({
-                'code_b64' : base64.urlsafe_b64encode(code),
+                'code_b64' : compatible_url_safe_base64_encode(code),
                 'delay' : expected_delay
             })
         else:

--- a/utils/cliparser.py
+++ b/utils/cliparser.py
@@ -160,7 +160,7 @@ def _(self, *args):
     return _
 
 parser.formatter._format_option_strings = parser.formatter.format_option_strings
-parser.formatter.format_option_strings = type(parser.formatter.format_option_strings)(_, parser, type(parser))
+parser.formatter.format_option_strings = type(parser.formatter.format_option_strings)(_, parser)
 
 option = parser.get_option("-h")
 option.help = option.help.capitalize().replace("Show this help message and exit", "Show help and exit.")

--- a/utils/rand.py
+++ b/utils/rand.py
@@ -1,5 +1,7 @@
 import random
 import string
+import sys
+
 
 def randint_n(n):
 
@@ -15,7 +17,12 @@ def randint_n(n):
     range_end = (10**n)-1
     return random.randint(range_start, range_end)
 
-def randstr_n(n, chars=string.letters + string.digits):
+if sys.version_info.major > 2 :
+    letters = string.ascii_letters
+else :
+    letters = string.letters
+
+def randstr_n(n, chars=letters + string.digits):
     return ''.join(
         random.choice(chars) for _ in range(n)
     )

--- a/utils/strings.py
+++ b/utils/strings.py
@@ -1,6 +1,5 @@
 import json
 import base64
-from itertools import izip_longest
 import hashlib
 
 def quote(command):


### PR DESCRIPTION
I patched incompatibilities by using conditionnal imports and fixing syntax incompatibilities (like parenthesis for print)

I manage to execute all tests series except node one because the docker container build failed (just like on your own branch if I'm not mistaken).

After my changes, I managed to exploit a machine both using python2.7.18 and 3.9.10 using -os-shell.

Thx in advance for feedback.