### PR TITLE
Python 3.10 support

### DIFF
--- a/core/plugin.py
+++ b/core/plugin.py
@@ -18,8 +18,8 @@ def _recursive_update(d, u):
     # Update value of a nested dictionary of varying depth
 
     for k, v in u.items():
-        if isinstance(d, collections.Mapping):
-            if isinstance(v, collections.Mapping):
+        if isinstance(d, collections.abc.Mapping):
+            if isinstance(v, collections.abc.Mapping):
                 r = _recursive_update(d.get(k, {}), v)
                 d[k] = r
             else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ chardet==3.0.4
 idna==2.8
 requests==2.22.0
 urllib3==1.24.1
-wsgiref==0.1.2


### PR DESCRIPTION
In order to use ``tplmap`` with python 3.10, I had to fix some issues:

## collections.mapping

### Error
```
Exiting: module 'collections' has no attribute 'Mapping'
```
### Fix
use ``collections.abc.mapping`` instead of ``collections.mapping`` (module change in python 3.3)

## wsgiref

### Error

It is not possible to install ``wsgiref``:
```
error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [9 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/private/var/folders/j3/l6mjg4f13bqff0z65zgjh1f00000gq/T/pip-install-72pbyadl/wsgiref_5ce53053f9ba423aaae0584a8c7470e2/setup.py", line 5, in <module>
          import ez_setup
        File "/private/var/folders/j3/l6mjg4f13bqff0z65zgjh1f00000gq/T/pip-install-72pbyadl/wsgiref_5ce53053f9ba423aaae0584a8c7470e2/ez_setup/__init__.py", line 170
          print "Setuptools version",version,"or greater has been installed."
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      SyntaxError: Missing parentheses in call to 'print'. Did you mean print(...)?
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.
```
### Fix

remove ``wsgiref`` as dependency because it is already been included as a standard library in Python 3